### PR TITLE
Widen deps and add release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,9 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- Once you upgraded, you'll be able to upgrade to `pytest` 8, and indirectly to `sybil` 6, which includes types hints. If you do so, you should remove the `mypy` exception for `sybil` in the `pyproject.toml` file.
+
+  Search for the `tool.mypy.overrides` section and remove the `"sybil", "sybil.*"` enties from the `module` list.
 
 ### Cookiecutter template
 
@@ -56,7 +58,7 @@ To upgrade without regenerating the project, you can follow these steps:
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- Add support for `pytest` 8.
 
 ### Cookiecutter template
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,8 +63,8 @@ lib = []
 model = []
 extra-lint-examples = [
   "pylint >= 2.17.3, < 4",
-  "pytest >= 7.4.2, < 9",
-  "sybil >= 6.0.3, < 7",
+  "pytest >= 7.3.0, < 9",
+  "sybil >= 5.0.3, < 7",
 ]
 dev-flake8 = [
   "flake8 == 6.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,8 +188,6 @@ module = [
   "github_action_utils",
   "mkdocs_macros.*",
   "semver.version",
-  "sybil",
-  "sybil.*",
 ]
 ignore_missing_imports = true
 


### PR DESCRIPTION
The `pytest` and `sybil` dependencies can be purely widen, supporting the same oldest versions as before, as we are not affected by the breaking changes.

This allows us to keep backwards compatibility for downstream project.
